### PR TITLE
Improve Member section with new billing and absence pages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem 'bootsnap', require: false
 gem 'pg'
 gem 'puma'
 
+gem 'date_validator'
 gem 'i18n-backend-side_by_side'
 gem 'rails-i18n'
 
@@ -77,6 +78,7 @@ group :development, :test do
   gem 'capybara'
   gem 'factory_bot_rails', '4.10.0'
   gem 'faker'
+  gem 'launchy'
   gem 'pdf-inspector', require: 'pdf/inspector'
   gem 'rspec-rails'
   gem 'spring-commands-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -72,8 +72,8 @@ GEM
     autoprefixer-rails (9.1.3)
       execjs
     aws-eventstream (1.0.1)
-    aws-partitions (1.100.0)
-    aws-sdk-core (3.24.1)
+    aws-partitions (1.102.0)
+    aws-sdk-core (3.25.0)
       aws-eventstream (~> 1.0)
       aws-partitions (~> 1.0)
       aws-sigv4 (~> 1.0)
@@ -81,7 +81,7 @@ GEM
     aws-sdk-kms (1.7.0)
       aws-sdk-core (~> 3)
       aws-sigv4 (~> 1.0)
-    aws-sdk-s3 (1.17.0)
+    aws-sdk-s3 (1.17.1)
       aws-sdk-core (~> 3, >= 3.21.2)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
@@ -95,7 +95,7 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11.0)
     cancancan (2.2.0)
-    capybara (3.6.0)
+    capybara (3.7.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -113,6 +113,9 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
+    date_validator (0.9.0)
+      activemodel
+      activesupport
     devise (4.5.0)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
@@ -145,7 +148,7 @@ GEM
       faraday (>= 0.7.4)
       http-cookie (~> 1.0.0)
     ffi (1.9.25)
-    font-awesome-sass (5.2.0)
+    font-awesome-sass (5.3.1)
       sassc (>= 1.11)
     formadmin (0.2.1)
       activeadmin
@@ -203,6 +206,8 @@ GEM
       activerecord
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -241,8 +246,8 @@ GEM
       hashery (~> 2.0)
       ruby-rc4
       ttfunk
-    pg (1.0.0)
-    phony (2.16.4)
+    pg (1.1.2)
+    phony (2.16.5)
     phony_rails (0.14.7)
       activesupport (>= 3.0)
       phony (> 2.15)
@@ -320,11 +325,11 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
     ruby-rc4 (0.1.5)
-    rubyXL (3.3.29)
+    rubyXL (3.3.30)
       nokogiri (>= 1.4.4)
       rubyzip (>= 1.1.6)
     ruby_dep (1.5.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     safe_yaml (1.0.4)
     sass (3.5.7)
       sass-listen (~> 4.0.0)
@@ -344,9 +349,9 @@ GEM
       skylight-core (= 2.0.2)
     skylight-core (2.0.2)
       activesupport (>= 4.2.0)
-    slim (3.0.9)
+    slim (4.0.1)
       temple (>= 0.7.6, < 0.9)
-      tilt (>= 1.3.3, < 2.1)
+      tilt (>= 2.0.6, < 2.1)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-commands-rspec (1.0.4)
@@ -358,8 +363,8 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sucker_punch (2.1.0)
-      concurrent-ruby (~> 1.0.0)
+    sucker_punch (2.1.1)
+      concurrent-ruby (~> 1.0)
     temple (0.8.0)
     thor (0.20.0)
     thread_safe (0.3.6)
@@ -380,7 +385,7 @@ GEM
     vcr (4.0.0)
     warden (1.2.7)
       rack (>= 1.0)
-    web-console (3.6.2)
+    web-console (3.7.0)
       actionview (>= 5.0)
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
@@ -408,6 +413,7 @@ DEPENDENCIES
   bullet
   cancancan
   capybara
+  date_validator
   devise
   devise-i18n
   exception_notification
@@ -426,6 +432,7 @@ DEPENDENCIES
   jbuilder
   jquery-turbolinks
   jquery-ui-rails
+  launchy
   listen
   mini_magick
   momentjs-rails
@@ -461,4 +468,4 @@ RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.3
+   1.16.4

--- a/app/admin/absence.rb
+++ b/app/admin/absence.rb
@@ -55,8 +55,8 @@ ActiveAdmin.register Absence do
   permit_params(*%i[member_id started_on ended_on note])
 
   before_build do |absence|
-    absence.started_on ||= Date.current
-    absence.ended_on ||= Date.current
+    absence.started_on ||= Date.current.next_week
+    absence.ended_on ||= Date.current.next_week.end_of_week
   end
 
   config.per_page = 25

--- a/app/assets/javascripts/members.js.coffee
+++ b/app/assets/javascripts/members.js.coffee
@@ -8,6 +8,7 @@
 //= require jquery-ui/i18n/datepicker-fr-CH
 //= require jquery-ui/i18n/datepicker-de
 //= require forms
+//= require turbolinks
 
 selectDate = (dateText) ->
   $('.no_halfdays').hide()
@@ -19,13 +20,23 @@ selectDate = (dateText) ->
   unless $("label.halfday-#{dateText} input:enabled").length
     $('#subscribe-button').prop('disabled', true)
 
-$ ->
+datepickerFallback = ->
+  @dateFields = $('input.date-input')
+  return if @dateFields.length == 0 || @dateFields[0].type is 'date'
+  @dateFields.datepicker
+    dateFormat: 'yy-mm-dd',
+    minDate: @dateFields.attr('min'),
+    maxDate: @dateFields.attr('max')
+
+setDatepickerLocale = ->
   locale = $('body').data('locale')
   if locale == 'fr'
     $.datepicker.setDefaults $.datepicker.regional['fr-CH']
   else
     $.datepicker.setDefaults $.datepicker.regional[locale]
 
+setupDatepicker = ->
+  setDatepickerLocale()
   dateTexts = $('#datepicker').data('dates')
   if dateTexts
     [minDateText, ..., maxDateText] = dateTexts
@@ -59,4 +70,11 @@ $ ->
           $('.halfdays label').hide()
           $('#subscribe-button').prop('disabled', true)
           $('.halfdays input').prop('checked', false)
+
+
+$ ->
+  document.addEventListener "turbolinks:load", ->
+    setupDatepicker()
+    datepickerFallback()
+
 

--- a/app/assets/stylesheets/members.css.scss
+++ b/app/assets/stylesheets/members.css.scss
@@ -1,15 +1,15 @@
-@import "normalize";
-@import "font-awesome-sprockets";
-@import "font-awesome";
-@import "members/variables";
+@import 'normalize';
+@import 'font-awesome-sprockets';
+@import 'font-awesome';
+@import 'members/variables';
 
 body {
   width: 100%;
   margin: 0;
   padding: 0;
   // https://css-tricks.com/snippets/css/system-font-stack/
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
-    Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica,
+    Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
 }
 
 #body-wrapper {
@@ -33,6 +33,10 @@ a {
 p {
   line-height: $base-line-height;
   margin: 0 0 $base-spacing / 3 0;
+
+  &.alert {
+    color: $red;
+  }
 }
 
 label {
@@ -69,8 +73,15 @@ textarea {
   }
 }
 
-input[type="submit"],
-button[type="submit"] {
+input[type='date'] {
+  width: calc(100% - 22px);
+  @media screen and (min-width: 900px) {
+    width: 150px;
+  }
+}
+
+input[type='submit'],
+button[type='submit'] {
   color: white;
   border: solid 2px $green;
   padding: 9px;
@@ -99,7 +110,34 @@ ol {
   list-style-type: none;
   margin: 0;
   padding: 0;
-  line-height: 1.5em;
+  line-height: $base-line-height;
+
+  a.cancel {
+    margin-left: $small-spacing;
+  }
+
+  li.rejected {
+    text-decoration: line-through;
+    font-style: italic;
+  }
+
+  &.main {
+    list-style-type: disc;
+    list-style-position: outside;
+
+    li {
+      margin: $small-spacing / 2 0 0 $base-spacing;
+    }
+  }
+}
+
+ul.errors {
+  margin-top: $small-spacing;
+  padding: $small-spacing;
+  border: 2px solid $red;
+  border-radius: $base-border-radius;
+  font-weight: 700;
+  color: $red;
 }
 
 section {
@@ -143,12 +181,61 @@ section.welcome {
   }
 }
 
-@import "members/header_and_footer";
-@import "members/flashes";
-@import "members/recover_token";
-@import "members/halfdays";
-@import "members/calendar";
-@import "members/tooltip";
-@import "members/labels";
-@import "members/formtastic";
-@import "members/pretty_inputs";
+nav {
+  margin: $base-spacing 0 (-$small-spacing) 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-content: center;
+  align-items: baseline;
+
+  a {
+    display: inline-block;
+    color: $base-font-color;
+    border: 2px solid $green;
+    border-radius: $base-border-radius;
+
+    text-align: center;
+    flex: 1 1 auto;
+    padding: 0.5em;
+    width: 100%;
+    margin-bottom: $small-spacing;
+
+    @media screen and (min-width: 900px) {
+      max-width: 29%;
+    }
+
+    h2 {
+      margin: 0;
+    }
+
+    p {
+      margin: 0;
+      font-style: italic;
+    }
+
+    &:hover {
+      border-color: $dark-green;
+      color: $dark-green;
+    }
+
+    &.active {
+      border-color: $dark-green;
+      color: $base-font-color;
+      pointer-events: none;
+      cursor: default;
+    }
+  }
+}
+
+@import 'members/header_and_footer';
+@import 'members/flashes';
+@import 'members/recover_token';
+@import 'members/halfdays';
+@import 'members/billing';
+@import 'members/absences';
+@import 'members/calendar';
+@import 'members/tooltip';
+@import 'members/labels';
+@import 'members/formtastic';
+@import 'members/pretty_inputs';

--- a/app/assets/stylesheets/members/_absences.scss
+++ b/app/assets/stylesheets/members/_absences.scss
@@ -1,0 +1,21 @@
+form.new_absence {
+  .field_with_errors input {
+    border: 2px solid $red;
+  }
+
+  .input {
+    margin: $small-spacing 0;
+
+    @media screen and (min-width: 900px) {
+      margin: $small-spacing $small-spacing $small-spacing 0;
+      display: inline-block;
+    }
+
+    &.submit {
+      margin: $base-spacing 0 0 0;
+      @media screen and (min-width: 900px) {
+        margin: $small-spacing $small-spacing $small-spacing $small-spacing;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/members/_billing.scss
+++ b/app/assets/stylesheets/members/_billing.scss
@@ -1,0 +1,52 @@
+ul.billing {
+  li {
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+
+    padding: $small-spacing / 2 0;
+
+    &:nth-child(odd) {
+      background-color: #f6f6f6;
+    }
+
+    @media screen and (min-width: 900px) {
+      flex-wrap: nowrap;
+    }
+
+    span.date {
+      flex-basis: auto;
+      order: 2;
+
+      @media screen and (min-width: 900px) {
+        flex-basis: 6em;
+        order: 1;
+      }
+    }
+
+    span.info {
+      order: 1;
+      flex-basis: 100%;
+
+      @media screen and (min-width: 900px) {
+        order: 2;
+        flex-basis: auto;
+      }
+    }
+
+    span.file {
+      order: 3;
+      margin-left: $small-spacing;
+    }
+
+    span.amount {
+      order: 4;
+      flex-grow: 2;
+      text-align: right;
+    }
+
+    &.canceled span {
+      text-decoration: line-through;
+    }
+  }
+}

--- a/app/assets/stylesheets/members/_calendar.scss
+++ b/app/assets/stylesheets/members/_calendar.scss
@@ -10,6 +10,12 @@
   }
 }
 
+#ui-datepicker-div {
+  background: white;
+  padding: $small-spacing;
+  border-radius: $base-border-radius;
+}
+
 .ui-datepicker-header {
   height: 50px;
   line-height: 50px;
@@ -22,7 +28,6 @@
   height: 30px;
   text-indent: 9999px;
   border: 2px solid $green;
-  -webkit-border-radius: 100%;
   border-radius: 100%;
   cursor: pointer;
   overflow: hidden;
@@ -67,7 +72,7 @@
 .ui-datepicker-next:hover,
 .ui-datepicker-prev:hover:after,
 .ui-datepicker-next:hover:after {
-  border-color: $medium-gray;
+  border-color: $dark-green;
 }
 
 .ui-state-disabled,
@@ -121,12 +126,19 @@
   margin: 0 auto;
 }
 
-td.available .ui-state-default {
+td .ui-state-default {
   color: white;
   font-weight: 600;
   background-color: $light-gray;
   &:hover {
     background-color: $medium-gray;
+  }
+}
+
+td.ui-datepicker-unselectable,
+td.ui-state-disabled {
+  .ui-state-default:hover {
+    background-color: white;
   }
 }
 

--- a/app/assets/stylesheets/members/_halfdays.scss
+++ b/app/assets/stylesheets/members/_halfdays.scss
@@ -1,20 +1,3 @@
-ol.halfdays {
-  list-style-type: decimal;
-
-  li {
-    margin: $small-spacing / 2 0 0 $base-spacing;
-  }
-
-  form {
-    display: inline;
-  }
-
-  li.rejected {
-    text-decoration: line-through;
-    font-style: italic;
-  }
-}
-
 .halfdays-form {
   display: inline-block;
   width: 100%;
@@ -52,11 +35,11 @@ ol.halfdays {
     }
 
     ul.error_explanation {
-      color: red;
+      color: $red;
     }
 
     .field_with_errors input {
-      border: 2px solid red;
+      border: 2px solid $red;
     }
   }
 

--- a/app/assets/stylesheets/members/_tooltip.scss
+++ b/app/assets/stylesheets/members/_tooltip.scss
@@ -2,6 +2,7 @@
 .tooltip-toggle {
   cursor: pointer;
   position: relative;
+  margin-left: $small-spacing / 4;
 
   //Tooltip text container
   &::before {

--- a/app/controllers/members/absences_controller.rb
+++ b/app/controllers/members/absences_controller.rb
@@ -1,0 +1,35 @@
+class Members::AbsencesController < Members::BaseController
+  # GET /absences
+  def index
+    @absence = Absence.new(
+      started_on: Absence.min_started_on,
+      ended_on: Absence.min_started_on.end_of_week)
+  end
+
+  # POST /absences
+  def create
+    @absence = current_member.absences.new(protected_params)
+    respond_to do |format|
+      if @absence.save
+        flash[:notice] = t('.flash.notice')
+        format.html { redirect_to members_absences_path }
+      else
+        format.html { render :index }
+      end
+    end
+  end
+
+  # DELETE /absences/:id
+  def destroy
+    absence = current_member.absences.find(params[:id])
+    absence.destroy
+
+    redirect_to members_absences_path
+  end
+
+  private
+
+  def protected_params
+    params.require(:absence).permit(:started_on, :ended_on)
+  end
+end

--- a/app/controllers/members/billing_controller.rb
+++ b/app/controllers/members/billing_controller.rb
@@ -1,0 +1,8 @@
+class Members::BillingController < Members::BaseController
+  # GET /billing
+  def index
+    invoices = current_member.invoices.includes(pdf_file_attachment: :blob)
+    @open_invoices = invoices.open.order(date: :desc)
+    @billing_history = (invoices.not_open_or_sent + current_member.payments).sort_by(&:date).reverse
+  end
+end

--- a/app/controllers/members/halfday_participations_controller.rb
+++ b/app/controllers/members/halfday_participations_controller.rb
@@ -1,13 +1,17 @@
 class Members::HalfdayParticipationsController < Members::BaseController
+  # GET /halfday_participations
+  def index
+  end
+
   # POST /halfday_participations
   def create
     @halfday_participation = current_member.halfday_participations.new(protected_params)
     respond_to do |format|
       if @halfday_participation.save
         flash[:notice] = t('.flash.notice')
-        format.html { redirect_to members_member_path }
+        format.html { redirect_to members_halfday_participations_path }
       else
-        format.html { render 'members/members/show' }
+        format.html { render :index }
       end
     end
   end
@@ -17,7 +21,7 @@ class Members::HalfdayParticipationsController < Members::BaseController
     participation = current_member.halfday_participations.find(params[:id])
     participation.destroy if participation.destroyable?
 
-    redirect_to members_member_path
+    redirect_to members_halfday_participations_path
   end
 
   private

--- a/app/controllers/members/members_controller.rb
+++ b/app/controllers/members/members_controller.rb
@@ -1,5 +1,6 @@
 class Members::MembersController < Members::BaseController
   skip_before_action :authenticate_member!, only: %i[new create welcome]
+  before_action :redirect_current_member!, only: %i[new create welcome]
 
   # GET /new
   def new
@@ -7,7 +8,9 @@ class Members::MembersController < Members::BaseController
   end
 
   # GET /
-  def show; end
+  def show
+    redirect_to members_halfday_participations_path
+  end
 
   # POST /
   def create
@@ -26,6 +29,10 @@ class Members::MembersController < Members::BaseController
   def welcome; end
 
   private
+
+  def redirect_current_member!
+    redirect_to members_member_path if current_member
+  end
 
   def member_params
     params

--- a/app/controllers/members/sessions_controller.rb
+++ b/app/controllers/members/sessions_controller.rb
@@ -6,6 +6,7 @@ class Members::SessionsController < Members::BaseController
 
   # GET /login
   def new
+    redirect_to members_member_path if current_member
     @session = Session.new
   end
 

--- a/app/helpers/invoices_helper.rb
+++ b/app/helpers/invoices_helper.rb
@@ -5,8 +5,8 @@ module InvoicesHelper
     }.sort_by { |a| a.first }
   end
 
-  def display_object(invoice)
-    if invoice.object
+  def display_object(invoice, link: true)
+    if link && invoice.object
       auto_link invoice.object
     else
       t_invoice_object_type(invoice.object_type)

--- a/app/helpers/layouts_helper.rb
+++ b/app/helpers/layouts_helper.rb
@@ -1,0 +1,5 @@
+module LayoutsHelper
+  def nav_class(controller)
+    'active' if params[:controller] == "members/#{controller}"
+  end
+end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -25,6 +25,7 @@ class Invoice < ActiveRecord::Base
   scope :membership, -> { where(object_type: 'Membership') }
   scope :acp_share, -> { where(object_type: 'ACPShare') }
   scope :not_canceled, -> { where.not(state: CANCELED_STATE) }
+  scope :not_open_or_sent, -> { where.not(state: [NOT_SENT_STATE, OPEN_STATE]) }
   scope :cancelable, -> { where(state: [PENDING_STATE, OPEN_STATE]) }
   scope :overbalance, -> { where('balance > amount') }
   scope :with_overdue_notice, -> { open.where('overdue_notices_count > 0') }

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -187,7 +187,7 @@ class Member < ActiveRecord::Base
   end
 
   def absent?(date)
-    absences.any? { |absence| absence.period.include?(date) }
+    absences.any? { |absence| absence.period.include?(date.to_date) }
   end
 
   def membership(year = nil)

--- a/app/models/vegetable.rb
+++ b/app/models/vegetable.rb
@@ -4,6 +4,7 @@ class Vegetable < ApplicationRecord
   translated_attributes :name
 
   has_many :basket_contents
+  has_many :deliveries, through: :basket_contents
 
   default_scope { order_by_name }
 

--- a/app/views/layouts/members.html.slim
+++ b/app/views/layouts/members.html.slim
@@ -12,10 +12,45 @@ html
     #body-wrapper
       = render 'layouts/members/header'
       = render 'layouts/flashes'
-      = yield
+
+      section
+        - if current_member
+          h4 = current_member.name
+
+          - if next_basket = current_member.next_basket
+            ul
+              li == "#{Basket.model_name.human}: #{basket_size_description(next_basket)}"
+              - if BasketComplement.any?
+                li == "#{BasketComplement.model_name.human(count: next_basket.membership.memberships_basket_complements.count)}: #{basket_complements_description(next_basket.membership.memberships_basket_complements&.includes(:basket_complement))}"
+              li == "#{Distribution.model_name.human}: #{next_basket.distribution.name}"
+          - else
+            p
+              em.empty = t('.no_membership')
+
+          nav
+            =
+            = link_to members_halfday_participations_path(anchor: 'halfday_participations'), class: nav_class('halfday_participations') do
+              h2 = halfdays_human_name
+              - membership = current_member.current_year_membership || current_member.future_membership
+              p
+                - if membership
+                  = t('.halfdays_participation_recognized', recognized: membership.recognized_halfday_works, total: membership.halfday_works)
+                - else
+                  = t('.no_halfdays_participations_asked')
+            = link_to members_billing_path(anchor: 'billing'), class: nav_class('billing') do
+              h2 = t('.billing')
+              - open_invoice_count = current_member.invoices.open.count
+              - if open_invoice_count.positive?
+                p.alert = t('.open_invoices', count: open_invoice_count)
+              - else
+                p = t('.see_history')
+            = link_to members_absences_path(anchor: 'absences'), class: nav_class('absences') do
+              h2 = Absence.model_name.human(count: 2)
+              p = t('.absences_subtitle')
+        = yield
     footer
       p = link_to_acp_website
       - if Current.acp.languages.many?
         ul.locales
           - Current.acp.languages.each do |locale|
-            li = link_to locale, url_for(locale: locale), title: t("languages.#{locale}")
+            li = link_to locale, url_for(locale: locale), title: t("languages.#{locale}"), onclick: 'Turbolinks.clearCache()'

--- a/app/views/members/absences/index.html.slim
+++ b/app/views/members/absences/index.html.slim
@@ -1,0 +1,41 @@
+#absences
+section
+  h2 = t('.present_or_future_absences')
+  - @present_or_future_absences = current_member.absences.present_or_future
+  - if @present_or_future_absences.empty?
+    p.empty = t('.no_present_or_future_absences')
+  - else
+    ol.main
+      - @present_or_future_absences.each do |absence|
+        li
+          = t('.absence_line', start: l(absence.started_on), end: l(absence.ended_on))
+          == link_to t('.cancel_link'), [:members, absence], method: :delete, class: 'cancel'
+
+section
+  h2 = t('.form_title')
+  p = t('.explanation')
+  = form_for [:members, @absence] do |f|
+
+    - if @absence.errors.any?
+      ul.errors
+        - @absence.errors.full_messages.each do |msg|
+          li = msg
+
+    .input
+      = f.label :started_on, 'À partir du'
+      = f.date_field :started_on, placeholder: 'dd.mm.yyyy', min: Absence.min_started_on, max: Absence.max_ended_on, class: 'date-input'
+    .input
+      = f.label :ended_on, "Jusqu'au"
+      = f.date_field :ended_on, placeholder: 'dd.mm.yyyy', min: Absence.min_started_on, max: Absence.max_ended_on, class: 'date-input'
+    .input.submit
+      = f.submit t('.submit')
+
+section
+  h2 = t('.past_absences')
+  - @past_absences = current_member.absences.past.order('ended_on DESC')
+  - if @past_absences.empty?
+    p.empty = t('.no_past_absences')
+  - else
+    ol.main
+      - @past_absences.each do |absence|
+        li = t('.absence_line', start: l(absence.started_on), end: l(absence.ended_on))

--- a/app/views/members/billing/index.html.slim
+++ b/app/views/members/billing/index.html.slim
@@ -1,0 +1,58 @@
+#billing
+
+- if @open_invoices.any?
+  section
+    h2 = t('.open_invoices')
+    ul.billing
+      - @open_invoices.each do |invoice|
+        li
+          span.date = l(invoice.date, format: :number)
+          span.info = t('.open_invoice_info', id: invoice.id, type: display_object(invoice, link: false))
+          span.file
+            = link_to rails_blob_path(invoice.pdf_file, disposition: 'attachment'), class: 'pdf_link' do
+              = icon('far', 'file-pdf')
+          span.amount = number_to_currency(invoice.amount)
+
+section
+  h2 = t('.history')
+  - if @billing_history.empty?
+    p.empty = t('.no_billing_history')
+  - else
+    ul.billing
+      - @billing_history.each do |object|
+        li class=('canceled' if object.respond_to?(:canceled?) && object.canceled?)
+          span.date = l(object.date, format: :number)
+          - case object
+          - when Invoice
+            span.info
+              - if object.canceled?
+                = t('.canceled_invoice_info', id: object.id, type: display_object(object, link: false))
+              - else
+                = t('.invoice_info', id: object.id, type: display_object(object, link: false))
+            span.file
+              = link_to rails_blob_path(object.pdf_file, disposition: 'attachment'), class: 'pdf_link' do
+                = icon('far', 'file-pdf')
+            span.amount = number_to_currency(object.amount)
+          - when Payment
+            - if object.amount.positive?
+              span.info
+                - if object.invoice_id
+                  = t('.payment_info', invoice_id: object.invoice_id)
+                - else
+                  = t('.manual_payment_info')
+            - else
+              span.info = t('.refund_info')
+            span.amount = number_to_currency(-object.amount)
+
+section
+  ul
+    li
+      = Member.human_attribute_name(:billing_year_division)
+      = ': '
+      = t("billing.year_division.x#{current_member.billing_year_division}")
+    - if Current.acp.share_price
+      = Member.human_attribute_name(:acp_shares_number)
+      = ': '
+      = current_member.acp_shares_number
+
+  p.info = t('.explanation')

--- a/app/views/members/halfday_participations/index.html.slim
+++ b/app/views/members/halfday_participations/index.html.slim
@@ -1,27 +1,11 @@
-section
-  h4 = current_member.name
-
-  - if next_basket = current_member.next_basket
-    ul
-      li == "#{Basket.model_name.human}: #{basket_size_description(next_basket)}"
-      - if BasketComplement.any?
-        li == "#{BasketComplement.model_name.human(count: next_basket.membership.memberships_basket_complements.count)}: #{basket_complements_description(next_basket.membership.memberships_basket_complements&.includes(:basket_complement))}"
-      li == "#{Distribution.model_name.human}: #{next_basket.distribution.name}"
-      - [current_member.current_year_membership, current_member.future_membership].compact.each do |membership|
-        li
-          = "#{halfdays_human_name} (#{membership.fiscal_year}): "
-          b = "#{membership.recognized_halfday_works}/#{membership.halfday_works}"
-  - else
-    p
-      em.empty = t('.no_membership')
-
+#halfday_participations
 section
   h2 = t_halfday('.coming_halfday_participations')
   - @coming_participations = current_member.halfday_participations.coming.includes(:halfday).order('halfdays.date')
   - if @coming_participations.empty?
     p.empty = t('.no_coming_halfday_participations')
   - else
-    ol.halfdays
+    ol.main
       - @coming_participations.each do |participation|
         li
           == halfday_label(participation.halfday, date: true, date_format: :long)
@@ -29,14 +13,13 @@ section
           - if participation.carpooling?
             span title="#{participation.carpooling_phone.phony_formatted}"= ", #{t('.carpooling')}"
           - if participation.destroyable?
-            = ' –'
-            == link_to "&nbsp;#{t('.cancel_link')}".html_safe, [:members, participation], method: :delete
+            == link_to t('.cancel_link'), [:members, participation], method: :delete, class: 'cancel'
 
     - if @coming_participations.any? { |p| !p.destroyable? }
       p.info == t_halfday('.coming_halfday_cannot_be_cancel_explanation', days_count: Current.acp.halfday_participation_deletion_deadline_in_days, contact_link: mail_to(Current.acp.email, t('.contact_link')))
 
 section
-  h2 = t_halfday('.halfday_form_title')
+  h2 = t_halfday('.halfday_participation_form_title')
   - @halfdays = Halfday.available_for(current_member)
   - if @halfdays.empty?
     p.empty = t_halfday('.no_halfdays')
@@ -48,7 +31,7 @@ section
             #datepicker.calendar data={ dates: @halfdays.map(&:date).uniq.to_json, selected_date: @halfday_participation.halfday.date }
         .column-right
           .input
-            label Horaire, lieu et activité
+            label = t('.halfday_label')
             label.label-error= @halfday_participation.errors[:halfday].first
             .no_halfdays style='display: none;'
               p.empty = t_halfday('.no_halfdays_this_month')
@@ -59,11 +42,11 @@ section
                   span.checkmark
                   span.label = halfday_label(b.object).html_safe
           .input
-            label Nbr. de participants
+            label = t('.participants_count_label')
             - if @halfday_participation.errors[:participants_count].any?
               ul.error_explanation
                 - @halfday_participation.errors[:participants_count].each do |msg|
-                  li= msg
+                  li = msg
             = f.number_field :participants_count, step: 1, min: 1, class: 'participants_count', required: true
           .input
             label.title
@@ -86,7 +69,7 @@ section
   - if @past_participations.empty?
     p.empty = t('.no_past_halfday_participations')
   - else
-    ol.halfdays
+    ol.main
       - @past_participations.each do |participation|
         li class="#{participation.rejected? ? 'rejected' : ''}"
           == halfday_label(participation.halfday, date: true, date_format: :long)

--- a/app/views/members/halfdays/index.rss.builder
+++ b/app/views/members/halfdays/index.rss.builder
@@ -1,7 +1,7 @@
 xml.instruct! :xml, version: '1.0'
 xml.rss version: '2.0' do
   xml.channel do
-    xml.title t_halfday('.coming_halfdays')
+    xml.title t_halfday('members.halfday_participations.index.coming_halfday_participations')
     xml.link members_halfdays_url
 
     limit = @halfdays.size == (@limit + 1) ? @limit + 1 : @limit
@@ -16,14 +16,14 @@ xml.rss version: '2.0' do
     end
     if @halfdays.size > limit
       xml.item do
-        xml.title t('.extra_coming_halfdays',
+        xml.title t('members.halfday_participations.index.extra_coming_halfday_participations',
           count: @halfdays.size - limit,
           last_date: l(@halfdays.last.date, format: :long))
       end
     end
     if @halfdays.empty?
       xml.item do
-        xml.title t_halfday('.no_coming_halfdays')
+        xml.title t_halfday('members.halfday_participations.index.no_coming_halfday_participations')
       end
     end
   end

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -37,6 +37,7 @@ _:
           _de: 1. Monat vom Geschäftsjahr
           _fr: 1er mois de l'année fiscale
         halfday_availability_limit_in_days:
+          _de: Anmeldefrist (in Tagen)
           _fr: Limite d'inscription à l'avance (en jours)
         halfday_participation_deletion_deadline_in_days:
           _de: Abmeldungsfrist (in Tagen)

--- a/config/locales/formtastic.yml
+++ b/config/locales/formtastic.yml
@@ -12,6 +12,7 @@ _:
           _de: Leer lassen, wenn kein jährlicher Beitrag
           _fr: Laisser vide si aucune cotisation anuelle
         halfday_availability_limit_in_days:
+          _de: Nach dieser Frist ist keine Anmeldung mehr möglich. Leer lassen wenn keine Frist gewünscht ist.
           _fr: Passé cette limite, il n'est plus possible de s'inscrire. Laisser à zéro aucune limite.
         halfday_participation_deletion_deadline_in_days:
           _de: Leer lassen wenn keinen Frist gewünscht ist, eine Abmeldung während der ersten 24h ist in jedem Fall möglich.

--- a/config/locales/layouts.yml
+++ b/config/locales/layouts.yml
@@ -1,6 +1,15 @@
 _:
   layouts:
     members:
+      absences_subtitle:
+        _de: Informieren Sie uns!
+        _fr: Prévenez-nous!
+      billing:
+        _de: Rechnungsstellung
+        _fr: Facturation
+      halfdays_participation_recognized:
+        _de: "%{recognized}/%{total} geleistet"
+        _fr: "%{recognized}/%{total} effectuée(s)"
       header:
         contact:
           _de: Kontakt
@@ -8,6 +17,22 @@ _:
         logout:
           _de: Abmeldung
           _fr: Déconnexion
+      no_halfdays_participations_asked:
+        _de: Keine Verpflichtung
+        _fr: Aucun engagement
+      no_membership:
+        _de: Kein Abonnement
+        _fr: Aucun abonnement
+      open_invoices:
+        one:
+          _de: 1 offene Rechnung
+          _fr: 1 facture ouverte
+        other:
+          _de: "%{count} offene Rechnungen"
+          _fr: "%{count} factures ouvertes"
+      see_history:
+        _de: Verlauf anzeigen
+        _fr: Consulter l'historique
       title:
         _de: Mitgliederseite
         _fr: Page de Membre

--- a/config/locales/members.yml
+++ b/config/locales/members.yml
@@ -1,5 +1,71 @@
 _:
   members:
+    absences:
+      create:
+        flash:
+          notice:
+            _de: Danke, dass du uns informiert hast!
+            _fr: Merci de nous avoir prévenus!
+      index:
+        absence_line:
+          _de: "%{start} – %{end}"
+          _fr: "%{start} – %{end}"
+        cancel_link:
+          _de: abbrechen
+          _fr: annuler
+        explanation:
+          _de: Während Ihrer Abwesenheit können Sie gerne Ihre Tasche an Freunden, Nachbarn oder Familie schenken. Wenn dies leider nicht möglich ist, sind wir Ihnen dankbar, uns über Ihrer Abwesenheit mit dem unten stehenden Formular zu informieren. Ihre Tasche wird dann unter den anderen Mitgliedern geteilt. Diese Taschen werden nicht zurückerstattet.
+          _fr: Lors de votre absence, le plus simple est de proposer votre panier à vos ami(e)s, voisin(e)s, famille, ... Si malheureusement ce n'est pas possible, merci d'annoncer votre absence à l'aide du formulaire ci-dessous. Votre panier sera alors partagé avec les autres membres. Ces paniers ne sont pas remboursés.
+        form_title:
+          _de: Abwesenheit melden
+          _fr: Annoncer une absence
+        no_past_absences:
+          _de: Keine, weiter so!
+          _fr: Aucune, continuez comme ça!
+        no_present_or_future_absences:
+          _de: Keine, teilen Sie uns bitte Ihre Abwesenheiten mit dem unten stehenden Formular mit.
+          _fr: Aucune, merci d'annoncer votre absence à l'aide du formulaire ci-dessous.
+        past_absences:
+          _de: Ihre vergangene Abwesenheiten
+          _fr: Vos absences passées
+        present_or_future_absences:
+          _de: Ihre künftige oder aktuelle Abwesenheiten
+          _fr: Vos absences à venir ou en cours
+        submit:
+          _de: Senden
+          _fr: Envoyer
+    billing:
+      index:
+        canceled_invoice_info:
+          _de: 'Stornierte Rechnungen #%{id} (%{type})'
+          _fr: 'Facture annulée #%{id} (%{type})'
+        explanation:
+          _de: Die Einzahlungen mit Referenznummer (ESR) werden automatisch über Nacht bearbeitet. Bitte kontaktieren Sie uns, wenn eine Ihrer Einzahlungen nicht erscheint.
+          _fr: Les paiements avec numéro de référence (BVR) sont automatiquement traités durant la nuit, veuillez nous contacter si un de vos paiments n'apparaîtrait pas.
+        history:
+          _de: Verlauf
+          _fr: Historique
+        invoice_info:
+          _de: 'Rechnung #%{id} (%{type})'
+          _fr: 'Facture #%{id} (%{type})'
+        manual_payment_info:
+          _de: Einzahlung ohne Referenz
+          _fr: Paiement sans référence
+        no_billing_history:
+          _de: Im Moment keine Rechnung oder Einzahlung.
+          _fr: Aucune facture ou paiment pour le moment.
+        open_invoice_info:
+          _de: 'Offene Rechnung #%{id} (%{type})'
+          _fr: 'Facture ouverte #%{id} (%{type})'
+        open_invoices:
+          _de: Offene Rechnungen
+          _fr: Factures ouvertes
+        payment_info:
+          _de: 'Einzahlung der Rechnung #%{invoice_id}'
+          _fr: 'Paiement de la facture #%{invoice_id}'
+        refund_info:
+          _de: Rückerstattung
+          _fr: Remboursement
     flash:
       authentication_required:
         _de: Bitte melden Sie sich an, um zu Ihrem Konto zu gelangen.
@@ -13,23 +79,85 @@ _:
           notice:
             _de: Vielen Dank für Ihre Anmeldung!
             _fr: Merci pour votre inscription!
-    halfdays:
       index:
-        coming_halfdays/basket_preparation:
-          _de: Künftige Abpackungen der Taschen
-          _fr: Mises en panier à venir
-        coming_halfdays/halfday_work:
-          _de: Künftige ½ Tage
-          _fr: "½ journées à venir"
-        extra_coming_halfdays:
+        cancel_link:
+          _de: abbrechen
+          _fr: annuler
+        carpooling:
+          _de: Fahrgemeinschaften
+          _fr: covoiturage
+        carpooling_checkbox:
+          _de: Ich komme mit dem Auto und habe freie Plätze!
+          _fr: Je viens en voiture et j'ai de la place!
+        carpooling_phone:
+          _de: Meine Telefonnummer
+          _fr: Mon téléphone
+        carpooling_tooltip:
+          _de: Falls Sie mit dem Auto kommen und die Fahrt teilen wollen, kreuzen Sie bitte das Kästschen hier unten an. Die anderen Mitglieder, die an diesem Tag angemeldet sind, werden Ihre Telefonnummer bekommen.
+          _fr: Merci de cocher la case ci-dessous si vous vous déplacez en voiture et désirez partager le voyage. Votre numéro de téléphone sera partagé avec les autres membres inscrits le même jour.
+        coming_halfday_cannot_be_cancel_explanation/basket_preparation:
+          _de: Aus Organisationsgründe, die Anmeldungen zu den Abpackungen der Taschen, die in weniger als %{days_count} Tagen stattfinden, können nicht mehr abgesagt werden. Bei einer Verhinderung, bitte uns schreiben %{contact_link}.
+          _fr: Pour des raisons d'organisation, les inscriptions aux mises en panier qui ont lieu dans moins de %{days_count} jours ne peuvent plus être annulées. En cas d'empêchement, merci de nous %{contact_link}.
+        coming_halfday_cannot_be_cancel_explanation/halfday_work:
+          _de: Aus Organisationsgründe, die Anmeldungen zu den ½ Tage, die in weniger als %{days_count} Tagen stattfinden, können nicht mehr abgesagt werden. Bei einer Verhinderung, bitte uns schreiben %{contact_link}.
+          _fr: Pour des raisons d'organisation, les inscriptions aux ½ journées qui ont lieu dans moins de %{days_count} jours ne peuvent plus être annulées. En cas d'empêchement, merci de nous %{contact_link}.
+        coming_halfday_participations/basket_preparation:
+          _de: Ihre künftigen Abpackungen der Taschen
+          _fr: Vos mises en panier à venir
+        coming_halfday_participations/halfday_work:
+          _de: Ihre künftigen ½ Tage
+          _fr: Vos ½ journées à venir
+        contact_link:
+          _de: Kontakt aufnehmen
+          _fr: contacter
+        extra_coming_halfday_participations:
           _de: "... und noch weitere %{count} bis zum %{last_date}!"
           _fr: "... et encore %{count} autres jusqu'au %{last_date}!"
-        no_coming_halfdays/basket_preparation:
+        halfday_form_submit:
+          _de: Anmeldung
+          _fr: Inscription
+        halfday_label:
+          _de: Zeitplan, Standort und Arbeit
+          _fr: Horaire, lieu et activité
+        halfday_participation_form_title/basket_preparation:
+          _de: Anmeldung an einer Abpackung der Taschen
+          _fr: Inscription à une mise en panier
+        halfday_participation_form_title/halfday_work:
+          _de: Anmeldung an einem ½ Tag
+          _fr: Inscription à une ½ journée
+        no_coming_halfday_participations:
+          _de: Kein, bitte schreiben Sie sich mit dem Formular hier unten ein.
+          _fr: Aucune, merci de vous inscrire à l'aide du formulaire ci-dessous.
+        no_coming_halfday_participations/basket_preparation:
           _de: Momentan gibt es keine freie Abpackungen der Taschen.
           _fr: Aucune mises en panier disponible pour le moment.
-        no_coming_halfdays/halfday_work:
+        no_coming_halfday_participations/halfday_work:
           _de: Momentan gibt es keine freie ½ Tage.
           _fr: Aucune ½ journées disponible pour le moment.
+        no_halfdays/basket_preparation:
+          _de: Sorry, momentan gibt es keine freie Abpackung der Taschen.
+          _fr: Désolé, aucune mise en panier disponible pour le moment.
+        no_halfdays/halfday_work:
+          _de: Sorry, momentan gibt es keinen freien ½ Tag.
+          _fr: Désolé, aucune ½ journée disponible pour le moment.
+        no_halfdays_this_month/basket_preparation:
+          _de: In diesem Monat findet keine Abpakcung der Taschen statt.
+          _fr: Aucune mise en panier ce mois.
+        no_halfdays_this_month/halfday_work:
+          _de: In diesem Monat findet keinen ½ Tag statt.
+          _fr: Aucune ½ journée ce mois.
+        no_past_halfday_participations:
+          _de: Momentan nichts zu melden, wir freuen uns Ihnen zu sehen!
+          _fr: Rien à signaler pour le moment, on se réjouit de vous voir!
+        participants_count_label:
+          _de: Anzahl Teilnehmer
+          _fr: Nombre de participants
+        past_halfday_participations/basket_preparation:
+          _de: Ihre geleisteten Abpackungen der Taschen
+          _fr: Vos mises en panier effectuées
+        past_halfday_participations/halfday_work:
+          _de: Ihre geleisteten ½ Tage
+          _fr: Vos ½ journées effectuées
     members:
       new:
         acp_shares_text:
@@ -68,73 +196,6 @@ _:
         title:
           _de: Anmeldeformular
           _fr: Formulaire d'inscription
-      show:
-        cancel_link:
-          _de: abbrechen
-          _fr: annuler
-        carpooling:
-          _de: Fahrgemeinschaften
-          _fr: covoiturage
-        carpooling_checkbox:
-          _de: Ich komme mit dem Auto und habe freie Plätze!
-          _fr: Je viens en voiture et j'ai de la place!
-        carpooling_phone:
-          _de: Meine Telefonnummer
-          _fr: Mon téléphone
-        carpooling_tooltip:
-          _de: Falls Sie mit dem Auto kommen und die Fahrt teilen wollen, kreuzen Sie bitte das Kästschen hier unten an. Die anderen Mitglieder, die an diesem Tag angemeldet sind, werden Ihre Telefonnummer bekommen.
-          _fr: Merci de cocher la case ci-dessous si vous vous déplacez en voiture et désirez partager le voyage. Votre numéro de téléphone sera partagé avec les autres membres inscrits le même jour.
-        coming_halfday_cannot_be_cancel_explanation/basket_preparation:
-          _de: Aus Organisationsgründe, die Anmeldungen zu den Abpackungen der Taschen, die in weniger als %{days_count} Tagen stattfinden, können nicht mehr abgesagt werden. Bei einer Verhinderung, bitte uns schreiben %{contact_link}.
-          _fr: Pour des raisons d'organisation, les inscriptions aux mises en panier qui ont lieu dans moins de %{days_count} jours ne peuvent plus être annulées. En cas d'empêchement, merci de nous %{contact_link}.
-        coming_halfday_cannot_be_cancel_explanation/halfday_work:
-          _de: Aus Organisationsgründe, die Anmeldungen zu den ½ Tage, die in weniger als %{days_count} Tagen stattfinden, können nicht mehr abgesagt werden. Bei einer Verhinderung, bitte uns schreiben %{contact_link}.
-          _fr: Pour des raisons d'organisation, les inscriptions aux ½ journées qui ont lieu dans moins de %{days_count} jours ne peuvent plus être annulées. En cas d'empêchement, merci de nous %{contact_link}.
-        coming_halfday_participations/basket_preparation:
-          _de: Ihre künftigen Abpackungen der Taschen
-          _fr: Vos mises en panier à venir
-        coming_halfday_participations/halfday_work:
-          _de: Ihre künftigen ½ Tage
-          _fr: Vos ½ journées à venir
-        contact_link:
-          _de: Kontakt aufnehmen
-          _fr: contacter
-        halfday_form_submit:
-          _de: Anmeldung
-          _fr: Inscription
-        halfday_form_title/basket_preparation:
-          _de: Anmeldung an einer Abpackung der Taschen
-          _fr: Inscription à une mise en panier
-        halfday_form_title/halfday_work:
-          _de: Anmeldung an einem ½ Tag
-          _fr: Inscription à une ½ journée
-        no_coming_halfday_participations:
-          _de: Kein, bitte schreiben Sie sich mit dem Formular hier unten ein.
-          _fr: Aucune, merci de vous inscrire à l'aide du formulaire ci-dessous.
-        no_halfdays/basket_preparation:
-          _de: Sorry, momentan gibt es keine freie Abpackung der Taschen.
-          _fr: Désolé, aucune mise en panier disponible pour le moment.
-        no_halfdays/halfday_work:
-          _de: Sorry, momentan gibt es keinen freien ½ Tag.
-          _fr: Désolé, aucune ½ journée disponible pour le moment.
-        no_halfdays_this_month/basket_preparation:
-          _de: In diesem Monat findet keine Abpakcung der Taschen statt.
-          _fr: Aucune mise en panier ce mois.
-        no_halfdays_this_month/halfday_work:
-          _de: In diesem Monat findet keinen ½ Tag statt.
-          _fr: Aucune ½ journée ce mois.
-        no_membership:
-          _de: Kein Abonnement
-          _fr: Aucun abonnement
-        no_past_halfday_participations:
-          _de: Momentan nichts zu melden, wir freuen uns Ihnen zu sehen!
-          _fr: Rien à signaler pour le moment, on se réjouit de vous voir!
-        past_halfday_participations/basket_preparation:
-          _de: Ihre geleisteten Abpackungen der Taschen
-          _fr: Vos mises en panier effectuées
-        past_halfday_participations/halfday_work:
-          _de: Ihre geleisteten ½ Tage
-          _fr: Vos ½ journées effectuées
       welcome:
         return_to_acp_website:
           _de: Zurück zu %{link}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,9 @@ Rails.application.routes.draw do
       delete '/logout' => 'sessions#destroy', as: :logout
 
       resources :halfdays, only: :index
-      resources :halfday_participations
+      resources :halfday_participations, only: %i[index create destroy]
+      resources :absences, only: %i[index create destroy]
+      get 'billing' => 'billing#index'
       resource :member, only: %i[new show create], path: '' do
         get 'welcome', on: :collection
       end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -190,16 +190,13 @@ describe Member do
   end
 
   describe '#absent?' do
-    let(:member) { create(:member) }
-    before do
-      create(:absence,
-        member: member,
-        started_on: Date.current,
-        ended_on: 2.days.from_now
-      )
-    end
+    it 'returns true for a given date during the absence window' do
+      absence = create(:absence,
+        started_on: 2.weeks.from_now,
+        ended_on: 4.weeks.from_now)
 
-    specify { expect(member.absent?(Date.tomorrow)).to eq true }
+      expect(absence.member.absent?(3.weeks.from_now)).to eq true
+    end
   end
 
   describe '#deactivate!' do

--- a/spec/system/members/absences_spec.rb
+++ b/spec/system/members/absences_spec.rb
@@ -1,0 +1,34 @@
+require 'rails_helper'
+
+describe 'Absences' do
+  let(:member) { create(:member) }
+
+  before do
+    Capybara.app_host = 'http://membres.ragedevert.test'
+    login(member)
+  end
+
+  it 'adds new absence' do
+    visit '/'
+
+    click_on 'Absences'
+
+    fill_in 'À partir du', with: 2.weeks.from_now
+    fill_in "Jusqu'au", with: 3.weeks.from_now
+
+    click_button 'Envoyer'
+
+    expect(page).to have_content('Merci de nous avoir prévenus!')
+    expect(page).to have_content "#{I18n.l(2.weeks.from_now.to_date)} – #{I18n.l(3.weeks.from_now.to_date)}"
+  end
+
+  it 'lists previous absences' do
+    member.absences.build(
+      started_on: 3.weeks.ago,
+      ended_on: 2.weeks.ago).save!(validate: false)
+
+    visit '/absences'
+
+    expect(page).to have_content "#{I18n.l(3.weeks.ago.to_date)} – #{I18n.l(2.weeks.ago.to_date)}"
+  end
+end

--- a/spec/system/members/billing_spec.rb
+++ b/spec/system/members/billing_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+describe 'Billing' do
+  let(:member) { create(:member) }
+
+  before do
+    Capybara.app_host = 'http://membres.ragedevert.test'
+    login(member)
+  end
+
+  it 'list open invoices' do
+    create(:invoice, :open, :annual_fee, id: 4242,
+      member: member, date: '2018-2-1', annual_fee: 42)
+
+    visit '/'
+    click_on 'Facturation'
+
+    expect(page).to have_content('Factures ouvertes')
+    expect(page).to have_content('1 facture ouverte')
+    expect(page).to have_content(
+      ['01.02.2018', 'Facture ouverte #4242 (Cotisation annuelle)', 'CHF 42.00'].join)
+  end
+
+  it 'list invoices and payments history' do
+    inovice = create(:invoice, :halfday_participation, id: 242,
+      member: member, date: '2018-4-12', paid_missing_halfday_works_amount: 120)
+    create(:payment, invoice: inovice, member: member, date: '2018-5-1', amount: 120)
+
+    visit '/billing'
+
+    expect(page).to have_content('Historique')
+    expect(page).to have_content(
+      ['01.05.2018', 'Paiement de la facture #242', '-CHF 120.00'].join)
+    expect(page).to have_content(
+      ['12.04.2018', 'Facture #242 (½ Journée)', 'CHF 120.00'].join)
+  end
+end

--- a/spec/system/members/halfday_participations_spec.rb
+++ b/spec/system/members/halfday_participations_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'members page' do
+describe 'Halfday Participation' do
   let(:member) { create(:member) }
 
   before do
@@ -20,7 +20,7 @@ describe 'members page' do
     expect(page).to have_content('Merci pour votre inscription!')
     expect(page)
       .to have_content "#{I18n.l(halfday.date, format: :long).capitalize}, #{halfday.period}"
-    within('ol.halfdays') do
+    within('ol.main') do
       expect(page).not_to have_content 'covoiturage'
     end
   end
@@ -37,7 +37,7 @@ describe 'members page' do
     click_button 'Inscription'
 
     expect(page).to have_content('Merci pour votre inscription!')
-    within('ol.halfdays') do
+    within('ol.main') do
       expect(page).to have_content 'covoiturage'
     end
   end
@@ -53,7 +53,7 @@ describe 'members page' do
     click_button 'Inscription'
 
     expect(page).to have_content('Merci pour votre inscription!')
-    within('ol.halfdays') do
+    within('ol.main') do
       expect(page).to have_content 'covoiturage'
     end
   end

--- a/spec/system/members/members_spec.rb
+++ b/spec/system/members/members_spec.rb
@@ -159,7 +159,6 @@ describe 'members page' do
   end
 
   context 'existing member token' do
-    # let!(:halfday) { create(:halfday, date: 4.days.from_now) }
     before { login(member) }
 
     it 'shows current membership info and halfdays count' do
@@ -177,7 +176,7 @@ describe 'members page' do
       expect(page).to have_content 'Panier: Petit'
       expect(page).to have_content 'Complément panier: Oeufs'
       expect(page).to have_content 'Dépôt: Jardin de la main'
-      expect(page).to have_content "½ Journées (#{Date.current.year}): 0/3"
+      expect(page).to have_content "0/3 effectuée(s)"
     end
 
     it 'shows current membership info with custom coming basket' do
@@ -199,7 +198,7 @@ describe 'members page' do
       expect(page).to have_content 'Panier: 2x Grand'
       expect(page).to have_content 'Complément panier: Oeufs'
       expect(page).to have_content 'Dépôt: Vélo'
-      expect(page).to have_content "½ Journées (#{Date.current.year}): 0/3"
+      expect(page).to have_content "0/3 effectuée(s)"
     end
 
     it 'shows next year membership info and halfdays count' do
@@ -222,7 +221,7 @@ describe 'members page' do
       expect(page).to have_content 'Panier: Grand'
       expect(page).to have_content 'Complément panier: Fromage'
       expect(page).to have_content 'Dépôt: Vélo'
-      expect(page).to have_content "½ Journées (#{Date.current.year + 1}): 0/4"
+      expect(page).to have_content "0/4 effectuée(s)"
     end
 
     it 'shows with no membership' do

--- a/spec/system/members/sessions_spec.rb
+++ b/spec/system/members/sessions_spec.rb
@@ -28,7 +28,7 @@ describe 'Member sessions' do
 
     visit "/sessions/#{session.token}"
 
-    expect(current_path).to eq '/'
+    expect(current_path).to eq '/halfday_participations'
     expect(page).to have_content 'Vous êtes maintenant connecté.'
 
     delete_session(member)
@@ -71,7 +71,7 @@ describe 'Member sessions' do
 
     visit "/sessions/#{old_session.token}"
 
-    expect(current_path).to eq '/'
+    expect(current_path).to eq '/halfday_participations'
     expect(page).to have_content 'Vous êtes déjà connecté.'
   end
 
@@ -106,7 +106,7 @@ describe 'Member sessions' do
 
     visit "/#{member.reload.token}"
 
-    expect(current_path).to eq '/'
+    expect(current_path).to eq '/halfday_participations'
   end
 
   it 'update last usage column every hour when using the session' do


### PR DESCRIPTION
This patch adds more feature to the member page by adding a new top menu which allows to navigates to two more new sections.

The first one is about billing, showing the number of open invoices and the past payments and invoices. This should provide more transparency around billing.

The second one is about absences, giving the possibility to the member to enter is future absence on its own and also provides a list of the past ones.

![screen shot 2018-09-01 at 21 36 12](https://user-images.githubusercontent.com/1322/44949307-11cacf00-ae2f-11e8-8a3f-8c828b247123.png)