### PR TITLE
Add BasketComplement price type

### DIFF
--- a/app/admin/basket_complement.rb
+++ b/app/admin/basket_complement.rb
@@ -4,14 +4,28 @@ ActiveAdmin.register BasketComplement do
 
   index download_links: false do
     column :name
-    column :price, ->(bs) { number_to_currency(bs.price, precision: 3) }
-    column :annual_price, ->(bs) { number_to_currency(bs.annual_price) }
+    column :price_type, -> (bs) {
+      BasketComplement.human_attribute_name("price_type/#{bs.price_type}")
+    }
+    column :price, ->(bs) {
+      if bs.annual_price_type?
+        number_to_currency(bs.annual_price, precision: 2)
+      else
+        number_to_currency(bs.delivery_price, precision: 2) +
+        " (#{number_to_currency(bs.annual_price, precision: 2)})"
+      end
+    }
     actions
   end
 
   form do |f|
     f.inputs do
       translated_input(f, :names)
+      f.input :price_type,
+        as: :select,
+        collection: BasketComplement::PRICE_TYPES.map { |type|
+          [BasketComplement.human_attribute_name("price_type/#{type}"), type]
+        }
       f.input :price
       f.input :deliveries,
         as: :check_boxes,
@@ -21,7 +35,7 @@ ActiveAdmin.register BasketComplement do
     end
   end
 
-  permit_params :price, delivery_ids: [], names: I18n.available_locales
+  permit_params :price, :price_type, delivery_ids: [], names: I18n.available_locales
 
   config.filters = false
   config.sort_order = -> { "names->>'#{I18n.locale}'" }

--- a/app/admin/membership.rb
+++ b/app/admin/membership.rb
@@ -176,7 +176,9 @@ ActiveAdmin.register Membership do
             }
             if m.basket_complements.any?
               row(:basket_complements_price) {
-                display_price_description(m.basket_complements_price, basket_complements_price_info(m.baskets))
+                display_price_description(
+                  m.basket_complements_price,
+                  membership_basket_complements_price_info(m))
               }
               row(:basket_complements_annual_price_change) {
                 number_to_currency(m.basket_complements_annual_price_change)

--- a/app/helpers/memberships_helper.rb
+++ b/app/helpers/memberships_helper.rb
@@ -53,15 +53,44 @@ module MembershipsHelper
       }.join(' + ')
   end
 
-  def basket_complements_price_info(baskets)
-    baskets
-      .joins(:baskets_basket_complements)
-      .pluck('baskets_basket_complements.quantity', 'baskets_basket_complements.price')
-      .group_by { |_, price| price }
-      .sort
-      .map { |price, bbcs|
-        "#{bbcs.sum { |q,_| q }}x#{precise_cur(price)}"
-      }.join(' + ')
+  def membership_basket_complements_price_info(membership)
+    (
+      membership.memberships_basket_complements
+        .joins(:basket_complement)
+        .where(basket_complements: { price_type: 'annual' })
+        .order('memberships_basket_complements.price')
+        .map { |mbc|
+          "#{mbc.quantity}x#{precise_cur(mbc.price)}"
+        } +
+      membership.baskets
+        .joins(baskets_basket_complements: :basket_complement)
+        .where(basket_complements: { price_type: 'delivery' })
+        .pluck('baskets_basket_complements.quantity', 'baskets_basket_complements.price')
+        .group_by { |_, price| price }
+        .sort
+        .map { |price, bbcs|
+          "#{bbcs.sum { |q,_| q }}x#{precise_cur(price)}"
+        }
+    ).join(' + ')
+  end
+
+  def basket_complement_price_info(membership, basket_complement)
+    if basket_complement.annual_price_type?
+      mbc = membership.memberships_basket_complements
+        .where(basket_complement: basket_complement)
+        .first
+      "#{mbc.quantity}x#{precise_cur(mbc.price)}"
+    else
+      membership.baskets
+        .joins(baskets_basket_complements: :basket_complement)
+        .where(baskets_basket_complements: { basket_complement: basket_complement })
+        .pluck('baskets_basket_complements.quantity', 'baskets_basket_complements.price')
+        .group_by { |_, price| price }
+        .sort
+        .map { |price, bbcs|
+          "#{bbcs.sum { |q,_| q }}x#{precise_cur(price)}"
+        }.join(' + ')
+    end
   end
 
   def distributions_price_info(baskets)

--- a/app/models/basket.rb
+++ b/app/models/basket.rb
@@ -92,7 +92,7 @@ class Basket < ActiveRecord::Base
         baskets_basket_complements.build(
           basket_complement_id: mbc.basket_complement_id,
           quantity: mbc.season_quantity(delivery),
-          price: mbc.price)
+          price: mbc.delivery_price)
       end
   end
 

--- a/app/models/basket_complement.rb
+++ b/app/models/basket_complement.rb
@@ -1,6 +1,8 @@
 class BasketComplement < ActiveRecord::Base
   include TranslatedAttributes
 
+  PRICE_TYPES = %w[delivery annual]
+
   translated_attributes :name
 
   has_many :baskets_basket_complement, dependent: :destroy
@@ -11,12 +13,23 @@ class BasketComplement < ActiveRecord::Base
 
   default_scope { order_by_name }
 
-  def annual_price
-    (price * deliveries.size).round_to_five_cents
+  validates :price, numericality: { greater_than_or_equal_to: 0 }, presence: true
+  validates :price_type, inclusion: { in: PRICE_TYPES }
+
+  def annual_price_type?
+    price_type == 'annual'
   end
 
-  def annual_price=(annual_price)
-    self.price = annual_price / deliveries.size.to_f
+  def annual_price
+    if annual_price_type?
+      price
+    else
+      (price * deliveries.size).round_to_five_cents
+    end
+  end
+
+  def delivery_price
+    annual_price_type? ? 0 : price
   end
 
   def display_name; name end

--- a/app/models/baskets_basket_complement.rb
+++ b/app/models/baskets_basket_complement.rb
@@ -4,10 +4,15 @@ class BasketsBasketComplement < ActiveRecord::Base
 
   validates :basket_complement_id, uniqueness: { scope: :basket_id }
   validates :price, numericality: { greater_than_or_equal_to: 0 }, presence: true
+  validates :price, numericality: { equal_to: 0 }, if: :basket_complement_annual_price_type?
   validates :quantity, numericality: { greater_than_or_equal_to: 0 }, presence: true
 
   before_validation do
-    self.price ||= basket_complement&.price
+    self.price ||= basket_complement&.delivery_price
+  end
+
+  def basket_complement_annual_price_type?
+    basket_complement&.annual_price_type?
   end
 
   def description
@@ -16,9 +21,5 @@ class BasketsBasketComplement < ActiveRecord::Base
     when 1 then basket_complement.name
     else "#{quantity} x #{basket_complement.name}"
     end
-  end
-
-  def total_price
-    quantity * price
   end
 end

--- a/app/models/delivery.rb
+++ b/app/models/delivery.rb
@@ -45,7 +45,7 @@ class Delivery < ActiveRecord::Base
         mbc = membership_basket_complement_for(basket, complement)
         basket.add_complement!(complement,
           quantity: mbc.season_quantity(self),
-          price: mbc.price)
+          price: mbc.delivery_price)
       end
   end
 

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -134,15 +134,21 @@ class Membership < ActiveRecord::Base
   end
 
   def basket_complements_price
-    BasketComplement.pluck(:id).sum { |id| basket_complement_total_price(id) }
+    BasketComplement.all.sum { |bc| basket_complement_total_price(bc) }
   end
 
-  def basket_complement_total_price(basket_complement_id)
-    rounded_price(
-      baskets
-        .joins(:baskets_basket_complements)
-        .where(baskets_basket_complements: { basket_complement_id: basket_complement_id })
-        .sum('baskets_basket_complements.quantity * baskets_basket_complements.price'))
+  def basket_complement_total_price(basket_complement)
+    if basket_complement.annual_price_type?
+      memberships_basket_complements
+        .where(basket_complement: basket_complement)
+        .sum('memberships_basket_complements.quantity * memberships_basket_complements.price')
+    else
+      rounded_price(
+        baskets
+          .joins(:baskets_basket_complements)
+          .where(baskets_basket_complements: { basket_complement: basket_complement })
+          .sum('baskets_basket_complements.quantity * baskets_basket_complements.price'))
+    end
   end
 
   def distributions_price

--- a/app/models/memberships_basket_complement.rb
+++ b/app/models/memberships_basket_complement.rb
@@ -12,8 +12,8 @@ class MembershipsBasketComplement < ActiveRecord::Base
     self.price ||= basket_complement&.price
   end
 
-  def total_price
-    quantity * price
+  def delivery_price
+    basket_complement.annual_price_type? ? 0 : price
   end
 
   def season_quantity(delivery)

--- a/app/models/pdf/invoice.rb
+++ b/app/models/pdf/invoice.rb
@@ -328,7 +328,7 @@ module PDF
           .baskets
           .joins(:baskets_basket_complements)
           .where(baskets_basket_complements: { basket_complement: basket_complement })
-      "#{basket_complement.name} #{basket_complements_price_info(baskets)}"
+      "#{basket_complement.name} #{basket_complement_price_info(object, basket_complement)}"
     end
 
     def membership_distribution_description(distribution)

--- a/app/models/xlsx/billing.rb
+++ b/app/models/xlsx/billing.rb
@@ -31,7 +31,7 @@ module XLSX
 
       if BasketComplement.any?
         BasketComplement.all.each do |basket_complement|
-          total = @memberships.sum { |m| m.basket_complement_total_price(basket_complement.id) }
+          total = @memberships.sum { |m| m.basket_complement_total_price(basket_complement) }
           add_line("#{BasketComplement.model_name.human}: #{basket_complement.name}", total, basket_complement.price)
         end
         add_empty_line

--- a/config/locales/activerecord.yml
+++ b/config/locales/activerecord.yml
@@ -180,6 +180,15 @@ _:
         deliveries:
           _de: Lieferungen
           _fr: Livraisons
+        price_type:
+          _de: Preis pro
+          _fr: Prix par
+        price_type/annual:
+          _de: Jahr
+          _fr: Année
+        price_type/delivery:
+          _de: Lieferung
+          _fr: Livraison
       basket_content:
         basket_size:
           _de: Tasche

--- a/db/migrate/20180831071210_add_price_type_to_basket_complements.rb
+++ b/db/migrate/20180831071210_add_price_type_to_basket_complements.rb
@@ -1,0 +1,5 @@
+class AddPriceTypeToBasketComplements < ActiveRecord::Migration[5.2]
+  def change
+    add_column :basket_complements, :price_type, :string, default: 'delivery', null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_08_24_200109) do
+ActiveRecord::Schema.define(version: 2018_08_31_071210) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "hstore"
@@ -124,6 +124,7 @@ ActiveRecord::Schema.define(version: 2018_08_24_200109) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.jsonb "names", default: {}, null: false
+    t.string "price_type", default: "delivery", null: false
   end
 
   create_table "basket_complements_deliveries", force: :cascade do |t|

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -179,6 +179,11 @@ FactoryBot.define do
       deliveries_count 0
     end
 
+    trait :annual_price_type do
+      price_type 'annual'
+      price 200
+    end
+
     delivery_ids { Delivery.current_year.limit(deliveries_count).pluck(:id) }
   end
 

--- a/spec/models/basket_complement_spec.rb
+++ b/spec/models/basket_complement_spec.rb
@@ -32,6 +32,37 @@ describe BasketComplement do
     expect(basket3.complements_price).to eq 3.2 + 4.5
   end
 
+  it 'adds basket_complement with annual price type on subscribed baskets' do
+    basket_complement1 = create(:basket_complement, :annual_price_type, id: 1)
+    basket_complement2 = create(:basket_complement, id: 2, price: 4.5)
+
+    membership_1 = create(:membership, subscribed_basket_complement_ids: [1, 2])
+    membership_2 = create(:membership, subscribed_basket_complement_ids: [2])
+    membership_3 = create(:membership, subscribed_basket_complement_ids: [1])
+
+    delivery = create(:delivery)
+
+    basket1 = create(:basket, membership: membership_1, delivery: delivery)
+    basket2 = create(:basket, membership: membership_2, delivery: delivery)
+    basket3 = create(:basket, membership: membership_3, delivery: delivery)
+    basket3.update!(complement_ids: [1, 2])
+
+    basket_complement1.update!(delivery_ids: [delivery.id])
+    basket_complement2.update!(delivery_ids: [delivery.id])
+
+    basket1.reload
+    expect(basket1.complement_ids).to match_array [1, 2]
+    expect(basket1.complements_price).to eq 4.5
+
+    basket2.reload
+    expect(basket2.complement_ids).to match_array [2]
+    expect(basket2.complements_price).to eq 4.5
+
+    basket3.reload
+    expect(basket3.complement_ids).to match_array [1, 2]
+    expect(basket3.complements_price).to eq 4.5
+  end
+
   it 'removes basket_complement on subscribed baskets' do
     basket_complement1 = create(:basket_complement, id: 1, price: 3.2)
     basket_complement2 = create(:basket_complement, id: 2, price: 4.5)

--- a/spec/models/baskets_basket_complement_spec.rb
+++ b/spec/models/baskets_basket_complement_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe BasketsBasketComplement do
+  it 'validates that price is zero when basket complement has an annual price type' do
+    membership = create(:membership)
+    membership.reload
+    basket_complement = create(:basket_complement, :annual_price_type, id: 1, deliveries_count: 40)
+    membership.update!(memberships_basket_complements_attributes: {
+      '0' => { basket_complement_id: 1, price: '', quantity: 1 }
+    })
+    bbc = membership.baskets.last.baskets_basket_complements.first
+    expect(bbc.price).to be_zero
+
+    bbc.update(price: 42)
+
+    expect(bbc).not_to have_valid(:price)
+  end
+end


### PR DESCRIPTION
La lumière des champs has a special basket complement called "les voisins d'abord" which is always billed 200.- annualy but can have a different amount of deliveries over the year, for that reason the price per delivery doesn't play well.

This patch introduces a new price type logic for the basket complement which can be "delivery" (same behaviour as today) and a new "annual" type which set a fixed price per year whithout considering the number of deliveries.