### PR TITLE
Add Memberships renewal sidebar

### DIFF
--- a/app/assets/stylesheets/active_admin.scss
+++ b/app/assets/stylesheets/active_admin.scss
@@ -320,6 +320,10 @@ table.table-memberships {
   margin: 15px 0 25px;
 }
 
+.buttons.custom_sidebar {
+  margin: 20px 0 0;
+}
+
 form input[type='time'] {
   appearance: none;
   -webkit-appearance: none;

--- a/app/jobs/renewal_job.rb
+++ b/app/jobs/renewal_job.rb
@@ -1,0 +1,35 @@
+class RenewalJob < ApplicationJob
+  queue_as :default
+
+  def perform(membership, year)
+    fiscal_year = Current.acp.fiscal_year_for(year)
+    renew!(membership, fiscal_year)
+  end
+
+  private
+
+  def renew!(membership, fiscal_year)
+    renewal = Membership.new(membership.attributes.slice(*%w[
+      member_id
+      basket_size_id
+      basket_quantity
+      baskets_annual_price_change
+      depot_id
+      seasons
+      annual_halfday_works
+      halfday_works_annual_price
+      basket_complements_annual_price_change
+    ]).merge(
+      started_on: fiscal_year.beginning_of_year,
+      ended_on: fiscal_year.end_of_year
+    ))
+    membership.memberships_basket_complements.each do |mbc|
+      renewal.memberships_basket_complements.build(mbc.attributes.slice(*%w[
+        seasons
+        quantity
+        basket_complement_id
+      ]))
+    end
+    renewal.save!
+  end
+end

--- a/app/models/memberships_renewal.rb
+++ b/app/models/memberships_renewal.rb
@@ -1,0 +1,42 @@
+class MembershipsRenewal
+  MissingDeliveriesError = Class.new(StandardError)
+
+  attr_reader :next_fy
+
+  def initialize
+    @next_fy = Current.acp.fiscal_year_for(Date.today.year + 1)
+  end
+
+  def to_renew
+    Membership.current_year.where(renew: true)
+  end
+
+  def renewed
+    Membership.during_year(@next_fy).where(member_id: to_renew.pluck(:member_id))
+  end
+
+  def renewable
+    to_renew.where.not(member_id: renewed.pluck(:member_id))
+  end
+
+  def renewing?
+    latest_renewed_at = renewed.maximum(:created_at)
+    latest_renewed_at && latest_renewed_at > 5.seconds.ago
+  end
+
+  def renew
+    unless next_year_deliveries?
+      raise MissingDeliveriesError, 'Deliveries for next fiscal year are missing.'
+    end
+
+    renewable.find_each do |membership|
+      RenewalJob.perform_later(membership, @next_fy.year)
+    end
+  end
+
+  private
+
+  def next_year_deliveries?
+    Delivery.between(@next_fy.range).any?
+  end
+end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -5,7 +5,7 @@ Rails.application.configure do
 
   # Store files locally.
   config.active_storage.service = :local
-  config.active_job.queue_adapter = :inline
+  config.active_job.queue_adapter = :sucker_punch
 
   # In the development environment your application's code is reloaded on
   # every request. This slows down response time but is perfect for development

--- a/config/locales/active_admin.yml
+++ b/config/locales/active_admin.yml
@@ -223,6 +223,12 @@ _:
       invalid_foreign_key_alert:
         _de: Dieses Objekt kann nicht gelöscht werden, weil andere Objekte davon abhängen.
         _fr: Cet objet ne peut être supprimé car d'autres objets dépendent de lui.
+      renew_missing_deliveries_alert:
+        _de: Abonnements können nicht verlängert werden, wenn %{next_year} keine Lieferungen vorhanden sind!
+        _fr: Impossible de renouveler les abonnements si les livraisons %{next_year} n'existent pas!
+      renew_notice:
+        _de: Die Abonnements werden verlängert...
+        _fr: Les abonnements sont entrain d'être renouvelés...
     has_many_delete:
       _de: Löschen
       _fr: Supprimer
@@ -379,6 +385,40 @@ _:
         seasons:
           _de: Jahreszeiten (Sommer / Winter)
           _fr: Saisons (été / hiver)
+      index:
+        all_renewed:
+          one:
+            _de: "%{count_link} Abonnement %{year} wurde bereits verlängert."
+            _fr: "%{count_link} abonnement %{year} a déjà été renouvelé."
+          other:
+            _de: "%{count_link} Abonnements %{year} wurden bereits verlängert."
+            _fr: "%{count_link} abonnements %{year} ont déjà été renouvelés."
+        no_renewals:
+          _de: Kein Abonnement zu verlängern.
+          _fr: Aucun abonnement à renouveler.
+        none_renewed:
+          one:
+            _de: "%{count_link} Abonnement %{year} muss verlängert werden."
+            _fr: "%{count_link} abonnement %{year} doit être renouvelé."
+          other:
+            _de: "%{count_link} Abonnements %{year} müssen verlängert werden."
+            _fr: "%{count_link} abonnements %{year} doivent être renouvelés."
+        partially_renewed:
+          _de: "%{renewed_count} der %{count_link} Abonnements %{year} wurden bereits verlängert."
+          _fr: "%{renewed_count} des %{count_link} abonnements %{year} ont déjà été renouvelés."
+        renew_action:
+          one:
+            _de: "%{count} Abonnement verlängern"
+            _fr: Renouveler %{count} abonnement
+          other:
+            _de: "%{count} Abonnements verlängern"
+            _fr: Renouveler %{count} abonnements
+        renew_confirm:
+          _de: Sind Sie mehr als sicher?
+          _fr: Êtes-vous sûr de sûr?
+        renewing:
+          _de: Verlängerungen am laufen...
+          _fr: Renouvellements en cours...
       new:
         basket_and_depot:
           _de: Tasche und Depot
@@ -696,6 +736,9 @@ _:
       total:
         _de: Total
         _fr: Total
+      renewal:
+        _de: Verlängerungen
+        _fr: Renouvellements
     status_tag:
       active:
         _de: aktiv

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -84,6 +84,7 @@ FactoryBot.define do
       after :create do |member|
         create(:membership,
           member: member,
+          deliveries_count: 52,
           started_on: [Time.current.beginning_of_year, Date.current - 3.weeks].max)
       end
     end

--- a/spec/jobs/renewal_job_spec.rb
+++ b/spec/jobs/renewal_job_spec.rb
@@ -1,0 +1,76 @@
+require 'rails_helper'
+
+describe RenewalJob do
+  let(:next_fy) { Current.acp.fiscal_year_for(Date.today.year + 1) }
+
+  it 'raises when no next year deliveries' do
+    membership = create(:membership)
+
+    expect(Delivery.between(next_fy.range).count).to be_zero
+    expect { RenewalJob.perform_later(membership, next_fy.year) }
+      .to raise_error(ActiveRecord::RecordInvalid)
+  end
+
+  it 'renews a membership without complements' do
+    membership = create(:membership,
+      basket_quantity: 2,
+      basket_price: 42,
+      baskets_annual_price_change: 130,
+      depot_price: 3,
+      annual_halfday_works: 5,
+      halfday_works_annual_price: -60)
+    Delivery.create_all(1, next_fy.beginning_of_year)
+
+    membership.basket_size.update!(price: 41)
+    membership.depot.update!(price: 4)
+
+    expect { RenewalJob.perform_later(membership, next_fy.year) }
+      .to change(Membership, :count).by(1)
+
+    expect(Membership.last).to have_attributes(
+      member_id: membership.member_id,
+      basket_size_id: membership.basket_size_id,
+      basket_price: 41,
+      basket_quantity: 2,
+      baskets_annual_price_change: 130,
+      depot_id: membership.depot_id,
+      depot_price: 4,
+      annual_halfday_works: 5,
+      halfday_works_annual_price: -60,
+      started_on: next_fy.beginning_of_year,
+      ended_on: next_fy.end_of_year)
+  end
+
+  it 'renews a membership with complements and seasons' do
+    Current.acp.update!(
+      summer_month_range_min: 4,
+      summer_month_range_max: 9)
+    create(:basket_complement, id: 1, price: 3.2)
+    create(:basket_complement, id: 2, price: 4.5)
+    membership = create(:membership,
+      seasons: %w[summer],
+      memberships_basket_complements_attributes: {
+        '0' => { basket_complement_id: 1, price: 3, seasons: %w[winter], quantity: 1 },
+        '1' => { basket_complement_id: 2, price: 5, quantity: 2 }
+      })
+
+    Delivery.create_all(1, next_fy.beginning_of_year)
+
+    expect { RenewalJob.perform_later(membership, next_fy.year) }
+      .to change(Membership, :count).by(1)
+
+    renewal = Membership.last
+    expect(renewal).to have_attributes(
+      seasons: %w[summer])
+    expect(renewal.memberships_basket_complements.first).to have_attributes(
+      seasons: %w[winter],
+      basket_complement_id: 1,
+      price: 3.2,
+      quantity: 1)
+    expect(renewal.memberships_basket_complements.last).to have_attributes(
+      seasons: %w[summer winter],
+      basket_complement_id: 2,
+      price: 4.5,
+      quantity: 2)
+  end
+end


### PR DESCRIPTION
This new sidebar provides a quick way to renew all current fiscal year 
memberships that have been flagged for renewal.

- [x] Manage new basket_size/depot price changes

<img width="300" alt="screenshot 2018-10-28 at 11 15 36" src="https://user-images.githubusercontent.com/1322/47614613-e49f4380-daa2-11e8-9a25-244a5f7da194.png">
